### PR TITLE
Fix get_current_weather() exception

### DIFF
--- a/metno/__init__.py
+++ b/metno/__init__.py
@@ -111,10 +111,10 @@ class MetWeatherData:
 
     def get_current_weather(self):
         """Get the current weather data from met.no."""
-        timeseries = self.data["properties"]["timeseries"]
-        if timeseries:
+        try:
+            timeseries = self.data["properties"]["timeseries"]
             now = parse_datetime(timeseries[0]["time"])
-        else:
+        except (TypeError, KeyError, IndexError):
             now = datetime.datetime.now(pytz.utc)
         return self.get_weather(now, hourly=True)
 


### PR DESCRIPTION
Fix exception if `get_current_weather()` is called before `fetching_data()`

This causes a test to fail in https://github.com/home-assistant/core/pull/39493