### PR TITLE
Improved logged error

### DIFF
--- a/metno/__init__.py
+++ b/metno/__init__.py
@@ -102,7 +102,7 @@ class MetWeatherData:
                 return False
             self.data = await resp.json()
         except (asyncio.TimeoutError, aiohttp.ClientError) as err:
-            _LOGGER.error("%s returned %s", self._api_url, err)
+            _LOGGER.error("Access to %s returned error '%s'", self._api_url, type(err).__name__)
             return False
         except ValueError:
             _LOGGER.exception("Unable to parse json response from %s", self._api_url)

--- a/metno/__init__.py
+++ b/metno/__init__.py
@@ -95,7 +95,7 @@ class MetWeatherData:
     async def fetching_data(self, *_):
         """Get the latest data from met.no."""
         try:
-            with async_timeout.timeout(15):
+            with async_timeout.timeout(10):
                 resp = await self._websession.get(self._api_url, params=self._urlparams)
             if resp.status >= 400:
                 _LOGGER.error("%s returned %s", self._api_url, resp.status)

--- a/metno/__init__.py
+++ b/metno/__init__.py
@@ -95,7 +95,7 @@ class MetWeatherData:
     async def fetching_data(self, *_):
         """Get the latest data from met.no."""
         try:
-            with async_timeout.timeout(10):
+            with async_timeout.timeout(15):
                 resp = await self._websession.get(self._api_url, params=self._urlparams)
             if resp.status >= 400:
                 _LOGGER.error("%s returned %s", self._api_url, resp.status)


### PR DESCRIPTION
Currently is hard to understand what happened from the log.
For a Timeout error you get:

`ERROR (MainThread) [metno] https://aa015h6buqvih86i1.api.met.no/weatherapi/locationforecast/2.0/complete returned`

The message **returned** doesn't help a lot.
This PR change the log line to:

`ERROR (MainThread) [metno] Access to https://aa015h6buqvih86i1.api.met.no/weatherapi/locationforecast/2.0/complete returned error 'TimeoutError'`