### PR TITLE
Use ciso8601 for parsing time when already installed

### DIFF
--- a/metno/__init__.py
+++ b/metno/__init__.py
@@ -9,6 +9,11 @@ import aiohttp
 import async_timeout
 import pytz
 
+try:
+    import ciso8601
+except ImportError:
+    ciso8601 = None
+
 # https://api.met.no/weatherapi/weathericon/_/documentation/#___top
 CONDITIONS = {
     "clearsky": "sunny",
@@ -393,8 +398,16 @@ class AirQualityData:
         return True
 
 
-def parse_datetime(dt_str):
+
+
+
+def parse_datetime(dt_str: str) -> datetime.datetime:
     """Parse datetime."""
+    if ciso8601:
+        try:
+            return ciso8601.parse_datetime(dt_str)
+        except ValueError:
+            pass
     date_format = "%Y-%m-%dT%H:%M:%S %z"
     dt_str = dt_str.replace("Z", " +0000")
     return datetime.datetime.strptime(dt_str, date_format)


### PR DESCRIPTION
Parsing time was ~85% of the actual update runtime, now ~12%

HA already has `ciso8601` as a core dep so it will be used right away, but remain compat for uses outside of HA