### PR TITLE
Remove dependency on pytz

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
   directories:
   - "$HOME/.cache/pip"
 install:
-- pip install flake8 pylint xmltodict aiohttp async_timeout pytz
+- pip install flake8 pylint xmltodict aiohttp async_timeout
 language: python
 script:
 - flake8 metno --max-line-length=120

--- a/metno/__init__.py
+++ b/metno/__init__.py
@@ -7,7 +7,6 @@ from typing import Any, List
 
 import aiohttp
 import async_timeout
-import pytz
 
 # https://api.met.no/weatherapi/weathericon/_/documentation/#___top
 CONDITIONS = {
@@ -117,7 +116,7 @@ class MetWeatherData:
             timeseries = self.data["properties"]["timeseries"]
             now = parse_datetime(timeseries[0]["time"])
         except (TypeError, KeyError, IndexError):
-            now = datetime.datetime.now(pytz.utc)
+            now = datetime.datetime.now(datetime.timezone.utc)
         return self.get_weather(now, hourly=True)
 
     def get_forecast(self, time_zone, hourly=False, range_start=1, range_stop=None):
@@ -190,7 +189,7 @@ class MetWeatherData:
         if not entries:
             return {}
         res = dict()
-        res["datetime"] = time.astimezone(tz=pytz.utc).isoformat()
+        res["datetime"] = time.astimezone(tz=datetime.timezone.utc).isoformat()
         res["condition"] = CONDITIONS.get(get_data("symbol_code", entries))
         res["pressure"] = get_data("air_pressure_at_sea_level", entries)
         res["humidity"] = get_data("relative_humidity", entries)
@@ -324,7 +323,7 @@ class AirQualityData:
                 _LOGGER.error("%s returned %s", self._api_url, err)
                 return False
         try:
-            forecast_time = datetime.datetime.now(pytz.utc) + datetime.timedelta(
+            forecast_time = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(
                 hours=self._forecast
             )
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(
     name = 'PyMetno',
     packages = ['metno'],
-    install_requires=['xmltodict', "aiohttp>=3.0.6", "async_timeout>=3.0.0", 'pytz'],
+    install_requires=['xmltodict', "aiohttp>=3.0.6", "async_timeout>=3.0.0"],
     version = '0.11.0',
     description = 'A library to communicate with the met.no api',
     author='Daniel Hjelseth Høyer',


### PR DESCRIPTION
Some background/reasoning in https://blog.ganssle.io/articles/2018/03/pytz-fastest-footgun.html

I couldn't find an indication what Python versions should be supported, other than a 3.5 mention in `.travis.yml`. If by chance >= 3.11, could use `datetime.UTC` instead of `datetime.timezone.utc` throughout.

Caveat: untested.