### PR TITLE
don't overwrite day/night specific conditions

### DIFF
--- a/metno/__init__.py
+++ b/metno/__init__.py
@@ -59,8 +59,15 @@ CONDITIONS = {
 # include them.
 _VARIATIONS = {}
 for key, value in CONDITIONS.items():
-    if not key.endswith(("_day", "_night")):
+    # ignore keys with values specific for night or day
+    # their values may be night or day specific
+    if key.endswith("_day") or key.endswith("_night"):
+        continue
+    
+    # don't overwrite existing day or night conditions 
+    if not key + "_day" in CONDITIONS:
         _VARIATIONS[key + "_day"] = value
+    if not key + "_night" in CONDITIONS:
         _VARIATIONS[key + "_night"] = value
 CONDITIONS.update(_VARIATIONS)
 del _VARIATIONS


### PR DESCRIPTION
The CONDITIONS dict is a mapping of conditions returned by met.no to values returned by pyMetno. This code has a subtle bug. The code which adds the variations ends up overwriting the night and day specific conditions.

The clearsky: sunny dict entry generates an override for clearsky_night when the variations are generated.

The expected conditions in the dict for clearsky should be: {'clearsky': 'sunny', 'clearsky_night': 'clear-night',

What we get due to the bug is:
{'clearsky': 'sunny', 'clearsky_night': 'sunny',

This patch does the following:
1. avoids generating variations for entries with keys which end in _day or _night
2. checks if the key with the _day or _night suffix exists in the conditions before it appends the condition as a variation